### PR TITLE
fix the wrong dimensions of the ninepatch when the activity is hidden…

### DIFF
--- a/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
@@ -34,7 +34,7 @@ public class RCTImageCapInsetView extends ImageView {
         final RCTImageCache cache = RCTImageCache.getInstance();
 
         if (cache.has(key)) {
-            setBackground(cache.get(key));
+            setBackground(cache.get(key).getConstantState().newDrawable());
             return;
         }
 

--- a/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
@@ -56,35 +56,4 @@ public class RCTImageCapInsetView extends ImageView {
 
         task.execute();
     }
-
-	
-	/*
-	 * HACK: the following methods fix the wrong dimensions of the ninepatch when the activity is hidden and shown again,
-	 * and when the device is rotated. This hack is required because RN uses its own layout system that bypasses the android one.
-	 * In order to update the bounds of the background drawable, we pretend that the frame of the view has been changed.
-	 */
-		
-	@Override
-	protected void onWindowVisibilityChanged(int visibility) {
-		super.onWindowVisibilityChanged(visibility);       		
-		
-		if (visibility == android.view.View.VISIBLE) {			
-			fireFakeFrameChange();
-        }
-    }
-	
-	protected void onConfigurationChanged(android.content.res.Configuration newConfig) {
-		super.onConfigurationChanged(newConfig);
-		fireFakeFrameChange();
-    }
-	
-	private void fireFakeFrameChange() {		
-		final int left = getLeft();
-		final int top = getTop();
-		final int right = getRight();
-		final int bottom = getBottom();
-				
-		setFrame(left+1, top, right, bottom);
-		setFrame(left, top, right, bottom);		
-	}
 }

--- a/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
@@ -56,4 +56,35 @@ public class RCTImageCapInsetView extends ImageView {
 
         task.execute();
     }
+
+	
+	/*
+	 * HACK: the following methods fix the wrong dimensions of the ninepatch when the activity is hidden and shown again,
+	 * and when the device is rotated. This hack is required because RN uses its own layout system that bypasses the android one.
+	 * In order to update the bounds of the background drawable, we pretend that the frame of the view has been changed.
+	 */
+		
+	@Override
+	protected void onWindowVisibilityChanged(int visibility) {
+		super.onWindowVisibilityChanged(visibility);       		
+		
+		if (visibility == android.view.View.VISIBLE) {			
+			fireFakeFrameChange();
+        }
+    }
+	
+	protected void onConfigurationChanged(android.content.res.Configuration newConfig) {
+		super.onConfigurationChanged(newConfig);
+		fireFakeFrameChange();
+    }
+	
+	private void fireFakeFrameChange() {		
+		final int left = getLeft();
+		final int top = getTop();
+		final int right = getRight();
+		final int bottom = getBottom();
+				
+		setFrame(left+1, top, right, bottom);
+		setFrame(left, top, right, bottom);		
+	}
 }


### PR DESCRIPTION
… and shown again and when the device is rotated.

It should fixes the following:
https://github.com/madsleejensen/react-native-image-capinsets/issues/4

I know it's mostly a hack, but I didn't find a better way. 
The RN layout system (that bypasses the android way of laying out the views) introduces some problems that really crack my head. :)