### PR TITLE
Fix compilation error in RN 0.47.0

### DIFF
--- a/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetPackage.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetPackage.java
@@ -16,7 +16,6 @@ public class RCTImageCapInsetPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Method createJSModules was removed from RN 0.47. Which leads to compilation error due to @override annotation. This method can be removed right now (facebook/react-native#15232)