### PR TITLE
Resolves #13 - ImageBackground to allow children on iOS

### DIFF
--- a/ImageCapInset.ios.js
+++ b/ImageCapInset.ios.js
@@ -1,17 +1,13 @@
 import React, { Component } from 'react';
 import {
-  StyleSheet,
+  ImageBackground,
   Image,
 } from 'react-native';
-
-const styles = StyleSheet.create({
-
-});
 
 class ImageCapInset extends Component {
   render() {
     return (
-      <Image
+      <ImageBackground
         {...this.props}
         resizeMode={Image.resizeMode.stretch}
       />


### PR DESCRIPTION
Altering iOS implementation to use ImageBackground and allow the same
functionality that exists in Android.

Also removing unused `StyleSheet` import, and unused `styles` obj.