### PR TITLE
 Added a null check to setCapInsets, updated build.gradle file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,24 +1,18 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
-    }
-}
-
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION   = 28
+def DEFAULT_BUILD_TOOLS_VERSION   = "28.0.3"
+def DEFAULT_TARGET_SDK_VERSION    = 28
+def DEFAULT_MIN_SDK_VERSION       = 16
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
-        versionName "1.0"
     }
     lintOptions {
         abortOnError false
@@ -26,5 +20,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
@@ -21,7 +21,11 @@ public class RCTImageCapInsetView extends ImageView {
 
     public void setCapInsets(Rect insets) {
         mCapInsets = insets;
-        reload();
+
+        if (this.mUri != null)
+        {
+            reload();
+        }
     }
 
     public void setSource(String uri) {

--- a/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
@@ -22,10 +22,7 @@ public class RCTImageCapInsetView extends ImageView {
     public void setCapInsets(Rect insets) {
         mCapInsets = insets;
 
-        if (this.mUri != null)
-        {
-            reload();
-        }
+        reload();
     }
 
     public void setSource(String uri) {
@@ -34,6 +31,11 @@ public class RCTImageCapInsetView extends ImageView {
     }
 
     public void reload() {
+        if (this.mUri == null)
+        {
+            return;
+        }
+
         final String key = mUri + "-" + mCapInsets.toShortString();
         final RCTImageCache cache = RCTImageCache.getInstance();
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/madsleejensen/react-native-image-capinsets.git"
   },
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "android support for Image `capInsets`",
   "author": {
     "name": "Mads Lee Jensen",


### PR DESCRIPTION
1. Added a null check to the setCapInsets method. Usually it's never called before the uri is set, but in one case it happened in reserve and failed with an error. I don't see a reason to not have the check.
2. Updated build.gradle file to support external project variables. Updated gradle wrapper version for 0.59 RN support.