### PR TITLE
2 crash fixes

### DIFF
--- a/ImageCapInset.android.js
+++ b/ImageCapInset.android.js
@@ -34,7 +34,7 @@ class ImageCapInset extends Component {
 
 ImageCapInset.propTypes = {
   ...View.propTypes,
-  source: Image.propTypes.source,
+  source: PropTypes.source,
   capInsets: PropTypes.shape({
     top: PropTypes.number,
     left: PropTypes.number,

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,5 +26,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/RCTImageCapInsetView.java
@@ -41,6 +41,10 @@ public class RCTImageCapInsetView extends ImageView {
         RCTImageLoaderTask task = new RCTImageLoaderTask(mUri, getContext(), new RCTImageLoaderListener() {
             @Override
             public void onImageLoaded(Bitmap bitmap) {
+                if (bitmap == null) {
+                  return;
+                }
+
                 int ratio = Math.round(bitmap.getDensity() / 160);
                 int top = mCapInsets.top * ratio;
                 int right = bitmap.getWidth() - (mCapInsets.right * ratio);

--- a/android/src/main/java/dk/madslee/imageCapInsets/utils/RCTImageLoaderTask.java
+++ b/android/src/main/java/dk/madslee/imageCapInsets/utils/RCTImageLoaderTask.java
@@ -24,7 +24,7 @@ public class RCTImageLoaderTask extends AsyncTask<String, Void, Bitmap> {
 
     @Override
     protected Bitmap doInBackground(String... params) {
-        if (mUri.startsWith("http")) {
+        if (mUri != null && mUri.startsWith("http")) {
             return loadBitmapByExternalURL(mUri);
         }
 


### PR DESCRIPTION
- RCTImageCapInsetView/onImageLoaded(): protect against a null bitmap
- RCTImageLoaderTask/doInBackground(): protect against a null url